### PR TITLE
fix: fix compile error on qmk_firmware

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -33,7 +33,8 @@ const uint16_t AML_TIMEOUT_MIN = 100;
 const uint16_t AML_TIMEOUT_MAX = 1000;
 const uint16_t AML_TIMEOUT_QU  = 50;   // Quantization Unit
 
-static const char BL = '\xB0'; // Blank indicator character
+// static const char BL = '\xB0'; // Blank indicator character, original
+#define BL '\xB0' // Used to Fix "error: initializer element is not constant" issue
 static const char LFSTR_ON[] PROGMEM = "\xB2\xB3";
 static const char LFSTR_OFF[] PROGMEM = "\xB4\xB5";
 


### PR DESCRIPTION
Facing follow error during compile, thus fix by using `#define`

```c
avr-gcc (GCC) 5.4.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Size before:
   text    data     bss     dec     hex filename
      0   27178       0   27178    6a2a keyball_keyball44_default.hex

Compiling: keyboards/keyball/lib/keyball/keyball.c                                                 keyboards/keyball/lib/keyball/keyball.c:54:24: error: initializer element is not constant
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
                        ^
keyboards/keyball/lib/keyball/keyball.c:54:24: note: (near initialization for ‘keyball.pressing_keys[0]’)
keyboards/keyball/lib/keyball/keyball.c:54:28: error: initializer element is not constant
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
                            ^
keyboards/keyball/lib/keyball/keyball.c:54:28: note: (near initialization for ‘keyball.pressing_keys[1]’)
keyboards/keyball/lib/keyball/keyball.c:54:32: error: initializer element is not constant
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
                                ^
keyboards/keyball/lib/keyball/keyball.c:54:32: note: (near initialization for ‘keyball.pressing_keys[2]’)
keyboards/keyball/lib/keyball/keyball.c:54:36: error: initializer element is not constant
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
                                    ^
keyboards/keyball/lib/keyball/keyball.c:54:36: note: (near initialization for ‘keyball.pressing_keys[3]’)
keyboards/keyball/lib/keyball/keyball.c:54:40: error: initializer element is not constant
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
                                        ^
keyboards/keyball/lib/keyball/keyball.c:54:40: note: (near initialization for ‘keyball.pressing_keys[4]’)
keyboards/keyball/lib/keyball/keyball.c:54:44: error: initializer element is not constant
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
                                            ^
keyboards/keyball/lib/keyball/keyball.c:54:44: note: (near initialization for ‘keyball.pressing_keys[5]’)
 [ERRORS]
 | 
 | 
 | 
make[1]: *** [builddefs/common_rules.mk:373: .build/obj_keyball_keyball44_default/lib/keyball/keyball.o] Error 1
make: *** [Makefile:415: keyball/keyball44:default] Error 1
```